### PR TITLE
Use http.Transport instead of http.Client.

### DIFF
--- a/replay/request_factory.go
+++ b/replay/request_factory.go
@@ -39,7 +39,7 @@ func NewRequestFactory() (factory *RequestFactory) {
 
 // Forward http request to given host
 func (f *RequestFactory) sendRequest(host *ForwardHost, request *http.Request) {
-	client := &http.Client{}
+	client := &http.Transport{}
 
 	// Change HOST of original request
 	URL := host.Url + request.URL.Path + "?" + request.URL.RawQuery
@@ -49,7 +49,7 @@ func (f *RequestFactory) sendRequest(host *ForwardHost, request *http.Request) {
 
 	Debug("Sending request:", host.Url, request)
 
-	resp, err := client.Do(request)
+	resp, err := client.RoundTrip(request)
 
 	if err == nil {
 		defer resp.Body.Close()


### PR DESCRIPTION
http.Client follows redirects by default and has support for cookies. http.Transport only performs one round-trip. Using http.Client is vulnerable to bad behaviour if there's a redirect loop somewhere in your app. Since we don't need (or want) redirects, and don't use cookies, http.Transport seems like the most logical choice.

(Before this patch, we ended up DOSing our own site whenever someone discovered a redirect loop)
