### PR TITLE
Added HTTP Basic Auth header injection support

### DIFF
--- a/replay/request_factory.go
+++ b/replay/request_factory.go
@@ -60,6 +60,10 @@ func (f *RequestFactory) sendRequest(host *ForwardHost, request *http.Request) {
 	request.RequestURI = ""
 	request.URL, _ = url.ParseRequestURI(URL)
 
+	if len(Settings.BasicAuthUser) > 0 && len(Settings.BasicAuthPassword) > 0 {
+		request.SetBasicAuth(Settings.BasicAuthUser, Settings.BasicAuthPassword)
+	}
+
 	Debug("Sending request:", host.Url, request)
 
 	resp, err := client.Do(request)

--- a/replay/settings.go
+++ b/replay/settings.go
@@ -23,6 +23,9 @@ type ReplaySettings struct {
 	Address        string
 	ForwardAddress string
 
+	BasicAuthUser     string
+	BasicAuthPassword string
+
 	Verbose bool
 }
 
@@ -78,6 +81,9 @@ func init() {
 
 	Settings.SetAddress()
 	flag.StringVar(&Settings.ForwardAddress, "f", defaultForwardAddress, "http address to forward traffic.\n\tYou can limit requests per second by adding `|num` after address.\n\tIf you have multiple addresses with different limits. For example: http://staging.example.com|100,http://dev.example.com|10")
+
+	flag.StringVar(&Settings.BasicAuthUser, "BasicAuth.User", "", "Inject Basic Auth Header in replay: Username")
+	flag.StringVar(&Settings.BasicAuthPassword, "BasicAuth.Password", "", "Inject Basic Auth Header in replay: Password")
 
 	flag.BoolVar(&Settings.Verbose, "verbose", false, "Log requests")
 }


### PR DESCRIPTION
Makes replaying possible in environments which require an additional HTTP Basic Auth header on the dev/staging side.
