### PR TITLE
Added Procfile to simplify debuging

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: python -m SimpleHTTPServer 8000
+replayed_web: python -m SimpleHTTPServer 8001
+listener: sudo -E go run gor.go listen -p 8000 -r localhost:8002 --verbose
+replay: go run gor.go replay -f localhost:8001 -p 8002 --verbose


### PR DESCRIPTION
￼This simple Procfile allows you to run listener, replay and 2 http servers (for listening and replaying) with 1 command. And it will show you nice colorized output for each process. To trigger listener just do: `curl localhost:8000`.

![image](https://f.cloud.github.com/assets/14009/1304158/6fac4bf2-3176-11e3-96ea-afa8f823788f.png)

Very good for live debugging. 

You need to have https://github.com/ddollar/foreman installed.
