### PR TITLE
Rename instances of "reply" to "replay"

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -251,7 +251,7 @@ func (e *Env) startFileListener() (p int) {
 func (e *Env) startFileUsingListener(port int, replayPort int) {
 	listener.Settings.Verbose = e.Verbose
 	listener.Settings.Address = "127.0.0.1"
-	listener.Settings.FileToReplyPath = "integration_request.gor"
+	listener.Settings.FileToReplayPath = "integration_request.gor"
 	listener.Settings.Port = port
 
 	if e.ListenerLimit != 0 {
@@ -263,7 +263,7 @@ func (e *Env) startFileUsingListener(port int, replayPort int) {
 
 func (e *Env) startFileUsingReplay() {
 	replay.Settings.Verbose = e.Verbose
-	replay.Settings.FileToReplyPath = "integration_request.gor"
+	replay.Settings.FileToReplayPath = "integration_request.gor"
 	replay.Settings.ForwardAddress = "127.0.0.1:" + strconv.Itoa(e.ForwardPort)
 
 	if e.ReplayLimit != 0 {
@@ -273,7 +273,7 @@ func (e *Env) startFileUsingReplay() {
 	replay.Run()
 }
 
-func TestSavingRequestToFileAndReplyThem(t *testing.T) {
+func TestSavingRequestToFileAndReplayThem(t *testing.T) {
 	processed := make(chan int)
 
 	listenHandler := func(w http.ResponseWriter, r *http.Request) {

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -51,13 +51,13 @@ func Run() {
 
 	var messageLogger *log.Logger
 
-	if Settings.FileToReplyPath != "" {
+	if Settings.FileToReplayPath != "" {
 
-		file, err := os.OpenFile(Settings.FileToReplyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+		file, err := os.OpenFile(Settings.FileToReplayPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
 		defer file.Close()
 
 		if err != nil {
-			log.Fatal("Cannot open file %q. Error: %s", Settings.FileToReplyPath, err)
+			log.Fatal("Cannot open file %q. Error: %s", Settings.FileToReplayPath, err)
 		}
 
 		messageLogger = log.New(file, "", 0)
@@ -66,7 +66,7 @@ func Run() {
 	if messageLogger == nil {
 		fmt.Println("Forwarding requests to replay server:", Settings.ReplayAddress, "Limit:", Settings.ReplayLimit)
 	} else {
-		fmt.Println("Saving requests to file", Settings.FileToReplyPath)
+		fmt.Println("Saving requests to file", Settings.FileToReplayPath)
 	}
 
 	// Sniffing traffic from given address

--- a/listener/settings.go
+++ b/listener/settings.go
@@ -20,7 +20,7 @@ type ListenerSettings struct {
 	Address string
 
 	ReplayAddress   string
-	FileToReplyPath string
+	FileToReplayPath string
 
 	ReplayLimit int
 
@@ -50,7 +50,7 @@ func init() {
 
 	flag.StringVar(&Settings.ReplayAddress, "r", defaultReplayAddress, "Address of replay server.")
 
-	flag.StringVar(&Settings.FileToReplyPath, "file", "", "File to store captured requests")
+	flag.StringVar(&Settings.FileToReplayPath, "file", "", "File to store captured requests")
 
 	flag.BoolVar(&Settings.Verbose, "verbose", false, "Log requests")
 }

--- a/replay/replay.go
+++ b/replay/replay.go
@@ -78,7 +78,7 @@ func Run() {
 
 	rm := NewReplayManager()
 
-	if Settings.FileToReplyPath != "" {
+	if Settings.FileToReplayPath != "" {
 		rm.RunReplayFromFile()
 	} else {
 		rm.RunReplayFromNetwork()
@@ -88,8 +88,8 @@ func Run() {
 func (self *ReplayManager) RunReplayFromFile() {
 	TotalResponsesCount = 0
 
-	log.Println("Starting file reply")
-	requests, err := parseReplyFile()
+	log.Println("Starting file replay")
+	requests, err := parseReplayFile()
 
 	if err != nil {
 		log.Fatal("Can't parse request: ", err)

--- a/replay/replay_file_parser.go
+++ b/replay/replay_file_parser.go
@@ -19,8 +19,8 @@ func (self ParsedRequest) String() string {
   return fmt.Sprintf("Request: %v, timestamp: %v", string(self.Request), self.Timestamp)
 }
 
-func parseReplyFile() (requests []ParsedRequest, err error) {
-  requests, err = readLines(Settings.FileToReplyPath)
+func parseReplayFile() (requests []ParsedRequest, err error) {
+  requests, err = readLines(Settings.FileToReplayPath)
 
   if err != nil {
     log.Fatalf("readLines: %s", err)

--- a/replay/settings.go
+++ b/replay/settings.go
@@ -28,7 +28,7 @@ type ReplaySettings struct {
 
 	ForwardAddress string
 
-	FileToReplyPath string
+	FileToReplayPath string
 
 	Verbose bool
 
@@ -101,7 +101,7 @@ func init() {
 
 	flag.StringVar(&Settings.ForwardAddress, "f", defaultForwardAddress, "http address to forward traffic.\n\tYou can limit requests per second by adding `|num` after address.\n\tIf you have multiple addresses with different limits. For example: http://staging.example.com|100,http://dev.example.com|10")
 
-	flag.StringVar(&Settings.FileToReplyPath, "file", "", "File to replay captured requests from")
+	flag.StringVar(&Settings.FileToReplayPath, "file", "", "File to replay captured requests from")
 
 	flag.BoolVar(&Settings.Verbose, "verbose", false, "Log requests")
 


### PR DESCRIPTION
This looks to have been a typo. Limited to file-based playback only. The
word "replay" makes more sense here, and is consistent with TCP playback.
