### PR TITLE
Document time delay in file-based replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can save request to file for replaying them later:
 gor listen -p 8080 -file requests.gor
 ```
 
-And replaying:
+Replay will preserve the original time differences between requests:
 ```
 gor replay -f "http://staging.server" -file requests.gor
 ```


### PR DESCRIPTION
This is an awesome feature that I've been looking for, for sometime. But I
had to dig through the code to verify that it did such. It should be called
out in the README instead!
