### PR TITLE
[#47 #36] Serialize requests to file using gob

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -94,7 +94,7 @@ func Run() {
 
 		if Settings.FileToReplayPath != "" {
 			go func() {
-				message := utils.ParsedRequest{time.Now().UnixNano(), m.Bytes()}
+				message := utils.RawRequest{time.Now().UnixNano(), m.Bytes()}
 				fileEnc.Encode(message)
 			}()
 		} else {

--- a/replay/replay_file_parser.go
+++ b/replay/replay_file_parser.go
@@ -10,7 +10,7 @@ import (
 	"github.com/buger/gor/utils"
 )
 
-func parseReplayFile() (requests []utils.ParsedRequest, err error) {
+func parseReplayFile() (requests []utils.RawRequest, err error) {
 	requests, err = readLines(Settings.FileToReplayPath)
 
 	if err != nil {
@@ -22,7 +22,7 @@ func parseReplayFile() (requests []utils.ParsedRequest, err error) {
 
 // readLines reads a whole file into memory
 // and returns a slice of request+timestamps.
-func readLines(path string) (requests []utils.ParsedRequest, err error) {
+func readLines(path string) (requests []utils.RawRequest, err error) {
 	file, err := ioutil.ReadFile(path)
 
 	if err != nil {
@@ -33,7 +33,7 @@ func readLines(path string) (requests []utils.ParsedRequest, err error) {
 	fileDec := gob.NewDecoder(fileBuf)
 
 	for err == nil {
-		var reqBuf utils.ParsedRequest
+		var reqBuf utils.RawRequest
 		err = fileDec.Decode(&reqBuf)
 
 		if err == io.EOF {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 )
 
-type ParsedRequest struct {
+type RawRequest struct {
 	Timestamp int64
 	Request   []byte
 }
 
-func (self ParsedRequest) String() string {
+func (self RawRequest) String() string {
 	return fmt.Sprintf("Request: %v, timestamp: %v", string(self.Request), self.Timestamp)
 }


### PR DESCRIPTION
To replace the serial plaintext representation of request and timestamp.
This fixes a bug whereby we were unable to delimit POST requests with bodies
because they didn't end in `\r\n\r\n`, frequently resulting in:

```
--- FAIL: TestSavingRequestToFileAndReplayThem (2.80 seconds)
        integration_test.go:346: Timeout error
```

Now we don't need to play guesswork with `Content-Length` headers or
introduce a custom delimiter. As a bonus, the code required is also slightly
simpler.

It is no longer possible to manipulate the `.gor` file by hand; but it does
make it trivial to write a tool that can parse and modify.

There are some `go fmt` indent changes rolled into `replay_file_parser`.
