### PR TITLE
Check packet has data via buffer size not PSH

### DIFF
--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -100,12 +100,12 @@ func (t *Listener) isIncomingDataPacket(buf []byte) bool {
 
 	// Because RAW_SOCKET can't be bound to port, we have to control it by ourself
 	if int(dest_port) == t.port {
-		// Check TCPPacket code for more description
-		flags := binary.BigEndian.Uint16(buf[12:14]) & 0x1FF
+		// Get the 'data offset' (size of the TCP header in 32-bit words)
+		dataOffset := (buf[12] & 0xF0) >> 4
 
 		// We need only packets with data inside
-		// TCP PSH flag indicate that packet have data inside
-		if (flags & TCP_PSH) != 0 {
+		// Check that the buffer is larger than the size of the TCP header
+		if len(buf) > int(dataOffset*4) {
 			// We should create new buffer because go slices is pointers. So buffer data shoud be immutable.
 			return true
 		}


### PR DESCRIPTION
The PSH flag tells the receiver to flush it's buffer. While this will
never be set for packets that have no data it can be, and often is, not
set for packets that do. For example, when a message spans more than one
segment the earlier segments often do not have the PSH flag set.

This alternative solution checks that the buffer is larger than the TCP
header.
