### PR TITLE
Changed `Indexor` to `Indexer` to comply with the newest ver of elastigo.

### DIFF
--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -21,7 +21,7 @@ type ESPlugin struct {
 	ApiPort string
 	Host    string
 	Index   string
-	indexor *core.BulkIndexor
+	indexor *core.BulkIndexer
 	done    chan bool
 }
 
@@ -80,7 +80,7 @@ func (p *ESPlugin) Init(URI string) {
 	api.Domain = p.Host
 	api.Port = p.ApiPort
 
-	p.indexor = core.NewBulkIndexorErrors(50, 60)
+	p.indexor = core.NewBulkIndexerErrors(50, 60)
 	p.done = make(chan bool)
 	p.indexor.Run(p.done)
 


### PR DESCRIPTION
A few days ago `mattbaird/elasitgo` changed the `indexor` to `indexer` which was breaking the gor code.
