### PR TITLE
Catch RedirectNotAllowed correctly

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -117,8 +117,10 @@ func (o *HTTPOutput) sendRequest(data []byte) {
 	stop := time.Now()
 
 	// We should not count Redirect as errors
-	if _, ok := err.(*RedirectNotAllowed); ok {
-		err = nil
+	if urlErr, ok := err.(*url.Error); ok {
+		if _, ok := urlErr.Err.(*RedirectNotAllowed); ok {
+			err = nil
+		}
 	}
 
 	if err == nil {


### PR DESCRIPTION
The error `RedirectNotAllowed` is wrapped by `url.Error`, causing it to not
currently be caught/ignored correctly for responses that issue redirects:

```
2014/01/06 12:17:17 Request error: Get https://example.com/foo: Redirects not allowed
```

It seems that two type assertions/conditions are required to unravel the
exact error. I can't see any way to write a test for this functionality --
the call to `defer()` or `log.Println()`.
