### PR TITLE
fix array out of bound error when http client posts big request body

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -16,18 +16,17 @@ func Start(stop chan int) {
 }
 
 // Copy from 1 reader to multiple writers
-func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
-	buf := make([]byte, 32*1024)
+func CopyMulty(src Input, writers ...io.Writer) {
 	wIndex := 0
 
 	for {
-		nr, er := src.Read(buf)
-		if nr > 0 {
-			Debug("Sending", src, ": ", string(buf[0:nr]))
+		buf, ok := src.Read()
+		if ok {
+			Debug("Sending", src, ": ", string(buf))
 
 			if Settings.splitOutput {
 				// Simple round robin
-				writers[wIndex].Write(buf[0:nr])
+				writers[wIndex].Write(buf)
 
 				wIndex++
 
@@ -36,18 +35,12 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 				}
 			} else {
 				for _, dst := range writers {
-					dst.Write(buf[0:nr])
+					dst.Write(buf)
 				}
 			}
 
-		}
-		if er == io.EOF {
-			break
-		}
-		if er != nil {
-			err = er
+		} else {
 			break
 		}
 	}
-	return err
 }

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -16,7 +16,7 @@ func TestEmitter(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)
@@ -49,7 +49,7 @@ func TestEmitterRoundRobin(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output1, output2}
 
 	Settings.splitOutput = true
@@ -82,7 +82,7 @@ func BenchmarkEmitter(b *testing.B) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)

--- a/input_dummy.go
+++ b/input_dummy.go
@@ -17,11 +17,10 @@ func NewDummyInput(options string) (di *DummyInput) {
 	return
 }
 
-func (i *DummyInput) Read(data []byte) (int, error) {
-	buf := <-i.data
-	copy(data, buf)
+func (i *DummyInput) Read() ([]byte, bool) {
+	buf, ok := <-i.data
 
-	return len(buf), nil
+	return buf, ok
 }
 
 func (i *DummyInput) emit() {

--- a/input_file.go
+++ b/input_file.go
@@ -34,11 +34,10 @@ func (i *FileInput) Init(path string) {
 	i.decoder = gob.NewDecoder(file)
 }
 
-func (i *FileInput) Read(data []byte) (int, error) {
-	buf := <-i.data
-	copy(data, buf)
+func (i *FileInput) Read() ([]byte, bool) {
+	buf, ok := <-i.data
 
-	return len(buf), nil
+	return buf, ok
 }
 
 func (i *FileInput) String() string {

--- a/input_raw.go
+++ b/input_raw.go
@@ -22,11 +22,10 @@ func NewRAWInput(address string) (i *RAWInput) {
 	return
 }
 
-func (i *RAWInput) Read(data []byte) (int, error) {
-	buf := <-i.data
-	copy(data, buf)
+func (i *RAWInput) Read() ([]byte, bool) {
+	buf, ok := <-i.data
 
-	return len(buf), nil
+	return buf, ok
 }
 
 func (i *RAWInput) listen(address string) {

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -20,7 +20,7 @@ func TestRAWInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	address := strings.Replace(listener.Addr().String(), "[::]", "127.0.0.1", -1)

--- a/input_tcp.go
+++ b/input_tcp.go
@@ -26,11 +26,10 @@ func NewTCPInput(address string) (i *TCPInput) {
 	return
 }
 
-func (i *TCPInput) Read(data []byte) (int, error) {
-	buf := <-i.data
-	copy(data, buf)
+func (i *TCPInput) Read() ([]byte, bool) {
+	buf, ok := <-i.data
 
-	return len(buf), nil
+	return buf, ok
 }
 
 func (i *TCPInput) listen(address string) {

--- a/input_tcp_test.go
+++ b/input_tcp_test.go
@@ -17,7 +17,7 @@ func TestTCPInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)
@@ -56,7 +56,7 @@ func BenchmarkTCPInput(b *testing.B) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -16,7 +16,7 @@ func TestLimiter(t *testing.T) {
 	}), 10)
 	wg.Add(10)
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -13,7 +13,7 @@ func TestFileOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewFileOutput("/tmp/test_requests.gor")
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)
@@ -32,7 +32,7 @@ func TestFileOutput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input2}
+	Plugins.Inputs = []Input{input2}
 	Plugins.Outputs = []io.Writer{output2}
 
 	go Start(quit)

--- a/output_http_test.go
+++ b/output_http_test.go
@@ -44,7 +44,7 @@ func TestHTTPOutput(t *testing.T) {
 
 	output := NewHTTPOutput(listener.Addr().String(), headers, methods, "")
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)
@@ -77,7 +77,7 @@ func BenchmarkHTTPOutput(b *testing.B) {
 
 	output := NewHTTPOutput(listener.Addr().String(), headers, methods, "")
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)

--- a/output_tcp_test.go
+++ b/output_tcp_test.go
@@ -19,7 +19,7 @@ func TestTCPOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String())
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)
@@ -72,7 +72,7 @@ func BenchmarkTCPOutput(b *testing.B) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String())
 
-	Plugins.Inputs = []io.Reader{input}
+	Plugins.Inputs = []Input{input}
 	Plugins.Outputs = []io.Writer{output}
 
 	go Start(quit)

--- a/plugins.go
+++ b/plugins.go
@@ -4,8 +4,12 @@ import (
 	"io"
 )
 
+type Input interface {
+	Read() (buf []byte, ok bool)
+}
+
 type InOutPlugins struct {
-	Inputs  []io.Reader
+	Inputs  []Input
 	Outputs []io.Writer
 }
 

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -67,7 +67,8 @@ func (t *Listener) readRAWSocket() {
 		log.Fatal(e)
 	}
 
-	buf := make([]byte, 4096*2)
+	// Ethernet MTU is 1500 bytes, local net MTU can be 16KB, so reserve a big buffer
+	buf := make([]byte, 4096*8)
 
 	for {
 		// Note: ReadFrom receive messages without IP header

--- a/test_input.go
+++ b/test_input.go
@@ -11,11 +11,10 @@ func NewTestInput() (i *TestInput) {
 	return
 }
 
-func (i *TestInput) Read(data []byte) (int, error) {
-	buf := <-i.data
-	copy(data, buf)
+func (i *TestInput) Read() ([]byte, bool) {
+	buf, ok := <-i.data
 
-	return len(buf), nil
+	return buf, ok
 }
 
 func (i *TestInput) EmitGET() {


### PR DESCRIPTION
This patch also improves performance a bit by not copying request buffer.

Fix issue #78.
