### PR TITLE
Refactor http output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ dbuild:
 dtest:
 	docker run -v `pwd`:/gopath/src/gor -t -i --env GORACE="halt_on_error=1" gor go test -race -v
 
+dbench:
+	docker run -v `pwd`:/gopath/src/gor -t -i gor go test -v -run NOT_EXISTING -bench HTTP
+
 drun:
 	docker run -v `pwd`:/gopath/src/gor -t -i gor go run $(SOURCE) --input-dummy=0 --output-dummy=0 --verbose
 


### PR DESCRIPTION
- Simplify worker spawn algorithm by introducing `workersCount` variable
- At least 1 worker should be always alive
- Remove stuff like goto labels and make overall code more "Go" way (use time.After instead of time.Sleep and etc)
- Rename `buf` to `queue` to avoid misunderstanding

/cc @joekiller 
