### PR TITLE
Add option to specify number of TCP worker

### DIFF
--- a/output_tcp.go
+++ b/output_tcp.go
@@ -21,11 +21,12 @@ type TCPOutput struct {
 }
 
 type TCPOutputConfig struct {
-	secure bool
+	secure  bool
+	workers int
 }
 
 // NewTCPOutput constructor for TCPOutput
-// Initialize 10 workers which hold keep-alive connection
+// Initialize TCPOutputConfig.workers workers which hold keep-alive connection
 func NewTCPOutput(address string, config *TCPOutputConfig) io.Writer {
 	o := new(TCPOutput)
 
@@ -37,7 +38,7 @@ func NewTCPOutput(address string, config *TCPOutputConfig) io.Writer {
 		o.bufStats = NewGorStat("output_tcp", 5000)
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < o.config.workers; i++ {
 		go o.worker()
 	}
 

--- a/settings.go
+++ b/settings.go
@@ -109,6 +109,7 @@ func init() {
 	flag.StringVar(&Settings.inputTCPConfig.keyPath, "input-tcp-certificate-key", "", "Path to PEM encoded certificate key file. Used when TLS turned on.")
 
 	flag.Var(&Settings.outputTCP, "output-tcp", "Used for internal communication between Gor instances. Example: \n\t# Listen for requests on 80 port and forward them to other Gor instance on 28020 port\n\tgor --input-raw :80 --output-tcp replay.local:28020")
+	flag.IntVar(&Settings.outputTCPConfig.workers, "output-tcp-workers", 10, "Enter a number to set the number of workers used for TCP output. default = 10.")
 	flag.BoolVar(&Settings.outputTCPConfig.secure, "output-tcp-secure", false, "Use TLS secure connection. --input-file on another end should have TLS turned on as well.")
 	flag.BoolVar(&Settings.outputTCPStats, "output-tcp-stats", false, "Report TCP output queue stats to console every 5 seconds.")
 


### PR DESCRIPTION
As we are using Goreplay in Kubernetes, we rely on having the TCP connections spread evenly across the Kubernetes service.
The Service Loadbalancer is not that accurate in distributing the connections when having a connection pool as low as 10, so we want to increase the number of active connections to mitigate this.