### PR TITLE
Fix remove '\n' before monkey on input-tcp mode

### DIFF
--- a/input_tcp.go
+++ b/input_tcp.go
@@ -117,7 +117,9 @@ func (i *TCPInput) handleConnection(conn net.Conn) {
 
 		if bytes.Equal(payloadSeparatorAsBytes[1:], line) {
 			// unread the '\n' before monkeys
-			buffer.UnreadByte()
+			if buffer.Len() > 0 {
+				buffer.Truncate(buffer.Len() - 1)
+			}
 			var msg Message
 			msg.Meta, msg.Data = payloadMetaWithBody(buffer.Bytes())
 			i.data <- &msg


### PR DESCRIPTION
If I get error on `buffer.UnreadByte()`, I have `bytes.Buffer: UnreadByte: previous operation was not a successful read`

The last '\n' before monkeys is not removed. If we chain multiple aggregators with input-tcp mode, one '\n' is add before separator on each aggregator.

